### PR TITLE
Add Traditional Chinese (zh_tw) translation

### DIFF
--- a/common/src/main/resources/assets/obscure_tooltips/lang/zh_tw.json
+++ b/common/src/main/resources/assets/obscure_tooltips/lang/zh_tw.json
@@ -1,0 +1,8 @@
+{
+  "rarity.common": "普通",
+  "rarity.uncommon": "罕見",
+  "rarity.rare": "稀有",
+  "rarity.epic": "史詩",
+  "toast.obscure_tooltips.hint_1": "啟用內建的 %s 資源包",
+  "toast.obscure_tooltips.hint_2": "內含動畫效果與樣式！"
+}


### PR DESCRIPTION
## Summary

Add Traditional Chinese (`zh_tw`) localization for Obscure Tooltips.

- Translate item rarity names
- Translate the Vibrant Tooltips resource pack hint
- Use terminology appropriate for Traditional Chinese users in Taiwan

## Check

- [x] No disruptive changes